### PR TITLE
introduce a preserve command line switch in debugfs 'rdump' command

### DIFF
--- a/e2fsck/extents.c
+++ b/e2fsck/extents.c
@@ -201,9 +201,12 @@ static errcode_t rewrite_extent_replay(e2fsck_t ctx, struct extent_list *list,
 {
 	errcode_t		retval;
 	ext2_extent_handle_t	handle;
-	unsigned int		i, ext_written;
+	unsigned int		i;
 	struct ext2fs_extent	*ex, extent;
 	blk64_t			start_val, delta;
+	#if defined(DEBUG) || defined(DEBUG_SUMMARY)
+	unsigned int ext_written;
+	#endif
 
 	/* Reset extent tree */
 	inode->i_flags &= ~EXT4_EXTENTS_FL;
@@ -223,7 +226,9 @@ static errcode_t rewrite_extent_replay(e2fsck_t ctx, struct extent_list *list,
 	if (retval)
 		return retval;
 
+	#if defined(DEBUG) || defined(DEBUG_SUMMARY)
 	ext_written = 0;
+	#endif
 
 	start_val = ext2fs_get_stat_i_blocks(ctx->fs, EXT2_INODE(inode));
 
@@ -263,7 +268,9 @@ static errcode_t rewrite_extent_replay(e2fsck_t ctx, struct extent_list *list,
 		retval = ext2fs_extent_fix_parents(handle);
 		if (retval)
 			goto err;
+		#if defined(DEBUG) || defined(DEBUG_SUMMARY)
 		ext_written++;
+		#endif
 	}
 
 	delta = ext2fs_get_stat_i_blocks(ctx->fs, EXT2_INODE(inode)) -

--- a/lib/ss/test_ss.c
+++ b/lib/ss/test_ss.c
@@ -136,9 +136,7 @@ int main(int argc, char **argv)
 }
 
 
-void test_cmd (argc, argv)
-    int argc;
-    char **argv;
+void test_cmd (int argc, char** argv)
 {
     printf("Hello, world!\n");
     printf("Args: ");


### PR DESCRIPTION
`debugfs` assumed the user wanted to preserve permissions and ownership when dumping a filesystem directory recursively with `rdump`. This is in opposition with the way the `dump/dump_inode` command has been designed, since it expose a `-p` command line switch to allow the end users to explicitly opt-in for permission and ownership preservation.
    
The inability to explicitly ask for permission and ownership preservation would get rdump to default to preservation, which is a problem when faced with filesystems having directories with the **read** flag set but not the **execute** flag set, since it would only allow to enumerate the directory content, but not see the inode details. Therefore getting debugfs in all kinds of issues trying to set ownership and permissions of files it can't see. 

This fix introduce a 'preserve' (`-p`) flag in rdump command so that users can explicitly opt-in for it, and debugfs will default to a safer way of operation (no preserve).

---

Note: I also fixed some code to get it to build with modern clang, and formatted the code with `clang-format` because the code is unreadable otherwise.