### PR TITLE
libsupport: fix function prototype for quota_write_inode()

### DIFF
--- a/lib/support/quotaio.h
+++ b/lib/support/quotaio.h
@@ -16,8 +16,7 @@
  *		AND/OR
  *		quota_data_add/quota_data_sub/quota_data_inodes();
  *	}
- *	quota_write_inode(qctx, USRQUOTA);
- *	quota_write_inode(qctx, GRPQUOTA);
+ *	quota_write_inode(qctx, (1 << USRQUOTA) | (1 << GRPQUOTA));
  *	quota_release_context(&qctx);
  * }
  *
@@ -223,7 +222,7 @@ void quota_data_add(quota_ctx_t qctx, struct ext2_inode_large *inode,
 		    ext2_ino_t ino, qsize_t space);
 void quota_data_sub(quota_ctx_t qctx, struct ext2_inode_large *inode,
 		    ext2_ino_t ino, qsize_t space);
-errcode_t quota_write_inode(quota_ctx_t qctx, enum quota_type qtype);
+errcode_t quota_write_inode(quota_ctx_t qctx, unsigned int qtype_bits);
 /* Flags for quota_read_all_dquots() */
 #define QREAD_USAGE  0x01
 #define QREAD_LIMITS 0x02


### PR DESCRIPTION
cherry-picked commit to pass CI tests (see https://github.com/onekey-sec/e2fsprogs/actions/runs/7884722094/job/21514337578)

> Commit 2d2d799c7261 ("Clean up codes for adding new quota type") changed the second paramter of quota_write_inode() from taking a single quota type to taking a logical OR of (1 << quota_types).

> The one thing this commit didn't change was the function prototype for quota_write_inode() in the header file from an enum to an unsigned int.  Most C compilers don't seem to mind, and omission is mostly harmless.  However, mingw64 does issue a warning which gets promoted to an error.

> Fixes: 2d2d799c7261 ("Clean up codes for adding new quota type")