### PR TITLE
Allow using exit_status to signal errors from debugfs subcommands

### DIFF
--- a/debugfs/debugfs.c
+++ b/debugfs/debugfs.c
@@ -2665,6 +2665,8 @@ int main(int argc, char **argv)
 		if (retval) {
 			ss_perror(ss_sci_idx, retval, request);
 			exit_status++;
+		} else {
+			exit_status = ss_get_exit_status(ss_sci_idx);
 		}
 	} else if (cmd_file) {
 		exit_status = source_file(cmd_file, ss_sci_idx);

--- a/lib/ss/execute_cmd.c
+++ b/lib/ss/execute_cmd.c
@@ -227,3 +227,13 @@ int ss_execute_line(int sci_idx, char *line_ptr)
 
     return(ret);
 }
+
+void ss_set_exit_status(int sci_idx, int code)
+{
+	ss_info(sci_idx)->exit_status = code;
+}
+
+int ss_get_exit_status(int sci_idx)
+{
+	return ss_info(sci_idx)->exit_status;
+}

--- a/lib/ss/ss.h
+++ b/lib/ss/ss.h
@@ -76,6 +76,8 @@ int ss_create_invocation(const char *, const char *, void *,
 void ss_delete_invocation(int);
 int ss_listen(int);
 int ss_execute_line(int, char *);
+void ss_set_exit_status(int sci_idx, int code);
+int ss_get_exit_status(int sci_idx);
 void ss_add_request_table(int, ss_request_table *, int, int *);
 void ss_delete_request_table(int, ss_request_table *, int *);
 void ss_abort_subsystem(int sci_idx, int code);


### PR DESCRIPTION
Use `exit_status` in libss2 as the exit status when executing a single debugfs subcommand with the `-R` command line switch. 

Adapt `rdump` signaling to this method.
