### PR TITLE
debian: temporarily lock libss2 dependency for debugfs

### DIFF
--- a/debian/e2fsprogs.shlibs.local
+++ b/debian/e2fsprogs.shlibs.local
@@ -1,2 +1,3 @@
 libext2fs 2 libext2fs2 (= ${binary:Version})
 libe2p 2 libext2fs2 (= ${binary:Version})
+libss 2 libss2 (= ${binary:Version})


### PR DESCRIPTION
Do not merge upstream.

This is a temporary fix until the required symbols (ss_get_exit_status, ss_set_exit_status) get into the symbols file and have the version bumped.